### PR TITLE
Fix tcp sock kernel hooks

### DIFF
--- a/tcbee-record/tcbee-ebpf/src/main.rs
+++ b/tcbee-record/tcbee-ebpf/src/main.rs
@@ -30,7 +30,8 @@ use probes::{
 #[no_mangle]
 static mut FILTER_PORT: u16 = 0;
 
-#[fentry(function="tcp_sendmsg")]
+/// tcp_write_xmit from net/ipv4/tcp_output.c
+#[fentry(function="__tcp_transmit_skb")]
 pub fn sock_sendmsg(ctx: FEntryContext) -> u32 {
     match try_sock_sendmsg(ctx) {
         Ok(ret) => ret,
@@ -38,7 +39,9 @@ pub fn sock_sendmsg(ctx: FEntryContext) -> u32 {
     }
 }
 
-#[fentry(function="tcp_recvmsg")]
+/// tcp_rcv_established from net/ipv4/tcp_input.c
+/// Only triggers after established state!
+#[fentry(function="tcp_rcv_established")]
 pub fn sock_recvmsg(ctx: FEntryContext) -> u32 {
     match try_tcp_recv_socket(ctx) {
         Ok(ret) => ret,
@@ -47,14 +50,14 @@ pub fn sock_recvmsg(ctx: FEntryContext) -> u32 {
 }
 
 // Performance variant of above functions that only capture cwnd
-#[fentry(function="tcp_sendmsg")]
+#[fentry(function="__tcp_transmit_skb")]
 pub fn cwnd_sock_sendmsg(ctx: FEntryContext) -> u32 {
     match try_sock_sendmsg_cwnd_only(ctx) {
         Ok(ret) => ret,
         Err(ret) => ret
     }
 }
-#[fentry(function="tcp_recvmsg")]
+#[fentry(function="tcp_rcv_established")]
 pub fn cwnd_sock_recvmsg(ctx: FEntryContext) -> u32 {
     match try_sock_recvmsg_cwnd_only(ctx) {
         Ok(ret) => ret,

--- a/tcbee-record/tcbee-ebpf/src/probes/tcp_socket.rs
+++ b/tcbee-record/tcbee-ebpf/src/probes/tcp_socket.rs
@@ -49,22 +49,28 @@ pub fn try_sock_recvmsg_cwnd_only(ctx: FEntryContext) -> Result<u32, u32> {
     let tcp_sck_ptr = sk_ptr as *const tcp_sock;
 
     let ports = unsafe { &(*sk_ptr).__sk_common.__bindgen_anon_3.skc_portpair };
-    let dport = (ports & 0xFFFF) as u16;
-    let sport = (ports >> 16) as u16;
+    // The order of ports in the socket is fixed for both sending and receiving
+    // So take the opposite order from sendmsg here
+let sport = ((ports & 0xFFFF) as u16).to_be();
+    let dport = ((ports >> 16) as u16).to_be();
+
+    // Swap source and destination for trace entry
+    let addr_v4 = unsafe { (*sk_ptr).__sk_common.__bindgen_anon_1.skc_addrpair.rotate_right(32) };
+    let ports = ports.rotate_right(16);
 
     unsafe {
         // dport needs to be called to_be otherwise value is wrong
-        if FILTER_PORT != 0 && sport != FILTER_PORT && dport.to_be() != FILTER_PORT {
+        if FILTER_PORT != 0 && sport != FILTER_PORT && dport != FILTER_PORT {
             //info!(&ctx, "Dropped: {} - {}",sport,dport.to_be());
             return Ok(0);
         }
 
         let cwnd_entry = cwnd_trace_entry {
             time: bpf_ktime_get_ns(),
-            addr_v4: (*sk_ptr).__sk_common.__bindgen_anon_1.skc_addrpair,
+            addr_v4,
             src_v6: (*sk_ptr).__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8,
             dst_v6: (*sk_ptr).__sk_common.skc_v6_daddr.in6_u.u6_addr8,
-            ports: *ports,
+            ports,
             family: (*sk_ptr).__sk_common.skc_family,
             snd_cwnd: read_kernel(&(*tcp_sck_ptr).snd_cwnd)?,
         };
@@ -95,12 +101,12 @@ pub fn try_sock_sendmsg_cwnd_only(ctx: FEntryContext) -> Result<u32, u32> {
     let tcp_sck_ptr = sk_ptr as *const tcp_sock;
 
     let ports = unsafe { &(*sk_ptr).__sk_common.__bindgen_anon_3.skc_portpair };
-    let dport = (ports & 0xFFFF) as u16;
-    let sport = (ports >> 16) as u16;
+    let dport = ((ports & 0xFFFF) as u16).to_be();
+    let sport = ((ports >> 16) as u16).to_be();
 
     unsafe {
         // dport needs to be called to_be otherwise value is wrong
-        if FILTER_PORT != 0 && sport != FILTER_PORT && dport.to_be() != FILTER_PORT {
+        if FILTER_PORT != 0 && sport != FILTER_PORT && dport != FILTER_PORT {
             //info!(&ctx, "Dropped: {} - {}",sport,dport.to_be());
             return Ok(0);
         }
@@ -140,12 +146,12 @@ pub fn try_sock_sendmsg(ctx: FEntryContext) -> Result<u32, u32> {
     let tcp_sck_ptr = sk_ptr as *const tcp_sock;
 
     let ports = unsafe { &(*sk_ptr).__sk_common.__bindgen_anon_3.skc_portpair };
-    let dport = (ports & 0xFFFF) as u16;
-    let sport = (ports >> 16) as u16;
+    let dport = ((ports & 0xFFFF) as u16).to_be();
+    let sport = ((ports >> 16) as u16).to_be();
 
     unsafe {
         // dport needs to be called to_be otherwise value is wrong
-        if FILTER_PORT != 0 && sport != FILTER_PORT && dport.to_be() != FILTER_PORT {
+        if FILTER_PORT != 0 && sport != FILTER_PORT && dport != FILTER_PORT {
             //info!(&ctx, "Dropped: {} - {}",sport,dport.to_be());
             return Ok(0);
         }
@@ -213,21 +219,25 @@ pub fn try_tcp_recv_socket(ctx: FEntryContext) -> Result<u32, u32> {
     let tcp_sck_ptr = sk_ptr as *const tcp_sock;
 
     let ports = unsafe { &(*sk_ptr).__sk_common.__bindgen_anon_3.skc_portpair };
-    let dport = (ports.to_be() & 0xFFFF) as u16;
-    let sport = (ports >> 16) as u16;
+    let sport = ((ports & 0xFFFF) as u16).to_be();
+    let dport = ((ports >> 16) as u16).to_be();
 
     unsafe {
         // dport needs to be called to_be otherwise value is wrong
-        if FILTER_PORT != 0 && sport != FILTER_PORT && dport.to_be() != FILTER_PORT {
+        if FILTER_PORT != 0 && sport != FILTER_PORT && dport != FILTER_PORT {
             return Ok(0);
         }
+
+        // Shift address to right, swaps source and destination
+        let addr_v4 = read_kernel(&(*sk_ptr).__sk_common.__bindgen_anon_1.skc_addrpair)?.rotate_right(32);
+        let ports = ports.rotate_right(16);
         
         let sock_entry = sock_trace_entry {
             time: bpf_ktime_get_ns(),
-            addr_v4: read_kernel(&(*sk_ptr).__sk_common.__bindgen_anon_1.skc_addrpair)?,
-            src_v6: read_kernel(&(*sk_ptr).__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8)?,
-            dst_v6: read_kernel(&(*sk_ptr).__sk_common.skc_v6_daddr.in6_u.u6_addr8)?,
-            ports: read_kernel(&(*sk_ptr).__sk_common.__bindgen_anon_3.skc_portpair)?,
+            addr_v4,
+            src_v6: read_kernel(&(*sk_ptr).__sk_common.skc_v6_daddr.in6_u.u6_addr8)?,
+            dst_v6: read_kernel(&(*sk_ptr).__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr8)?,
+            ports,
             family: read_kernel(&(*sk_ptr).__sk_common.skc_family)?,
             // SOCK Stats
             pacing_rate: read_kernel(&(*sk_ptr).sk_pacing_rate)?,

--- a/tcbee-record/tcbee/src/eBPF/probes/cwnd.rs
+++ b/tcbee-record/tcbee/src/eBPF/probes/cwnd.rs
@@ -23,12 +23,12 @@ impl CwndTracer {
 
         // Outgoing TCP
         let sendmsg: &mut FEntry = ebpf.program_mut("cwnd_sock_sendmsg").unwrap().try_into()?;
-        sendmsg.load("tcp_sendmsg", &btf)?;
+        sendmsg.load("__tcp_transmit_skb", &btf)?;
         sendmsg.attach()?;
 
         // Incoming TCP
         let recvmsg: &mut FEntry = ebpf.program_mut("cwnd_sock_recvmsg").unwrap().try_into()?;
-        recvmsg.load("tcp_recvmsg", &btf)?;
+        recvmsg.load("tcp_rcv_established", &btf)?;
         recvmsg.attach()?;
 
         // Start SOCK_SEND handling

--- a/tcbee-record/tcbee/src/eBPF/probes/kernel.rs
+++ b/tcbee-record/tcbee/src/eBPF/probes/kernel.rs
@@ -23,12 +23,12 @@ impl KernelTracer {
 
         // Outgoing TCP
         let sendmsg: &mut FEntry = ebpf.program_mut("sock_sendmsg").unwrap().try_into()?;
-        sendmsg.load("tcp_sendmsg", &btf)?;
+        sendmsg.load("__tcp_transmit_skb", &btf)?;
         sendmsg.attach()?;
 
         // Incoming TCP
         let recvmsg: &mut FEntry = ebpf.program_mut("sock_recvmsg").unwrap().try_into()?;
-        recvmsg.load("tcp_recvmsg", &btf)?;
+        recvmsg.load("tcp_v4_do_rcv", &btf)?;
         recvmsg.attach()?;
 
         // Start SOCK_SEND handling

--- a/tcbee-record/tcbee/src/eBPF/probes/kernel.rs
+++ b/tcbee-record/tcbee/src/eBPF/probes/kernel.rs
@@ -28,7 +28,7 @@ impl KernelTracer {
 
         // Incoming TCP
         let recvmsg: &mut FEntry = ebpf.program_mut("sock_recvmsg").unwrap().try_into()?;
-        recvmsg.load("tcp_v4_do_rcv", &btf)?;
+        recvmsg.load("tcp_rcv_established", &btf)?;
         recvmsg.attach()?;
 
         // Start SOCK_SEND handling


### PR DESCRIPTION
Changes send hook to __tcp_transmit_skb and receive hook to tcp_rcv_established
Also fixed parsing of ports from sk in eBPF probe